### PR TITLE
mesh tile original data

### DIFF
--- a/detour/tile.go
+++ b/detour/tile.go
@@ -85,6 +85,9 @@ type MeshTile struct {
 	// [Size: MeshHeader.OffMeshConCount]
 	OffMeshCons []OffMeshConnection
 
+	// The tile data. (Not directly accessed under normal situations.)
+	Data []byte
+
 	// Size of the tile data.
 	DataSize int32
 


### PR DESCRIPTION
I noticed that in the 'recastnavigation' project, the original 'data' is retained in 'dtMeshTile', but it is not retained in 'go-detour'. In my project, I may need to keep this original 'data' so that I can conveniently remove or rebuild 'MeshTile' at any time. Currently, I am using this to do some dynamic culling of mesh tiles. Regarding 'm.saltBits', when my navmesh construction granularity is very fine and the mesh tile is relatively small, the value of 'm.saltBits' is 8. At this time, the check of 'if m.saltBits < 10' will fail, causing the navmesh to fail to load.